### PR TITLE
Remove parameters remove_files and add_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,20 @@ Checks out sources from the build service.
 
 ### `out`: Build and/or Commit to build service
 
-First `osc rm` is called on all array members of `remove_files` if present.
+First `osc addremove` is called to update the package file list according to
+the local resource directory.
 
 If a `build` hash is present in the params, `osc build` will be called for the specified `repository` and `version`.
 The build is non-interactive so osc trusts all projects which are part of the specified build project.
 
 The resource will commit changes to the build service if a commit message is present in `message`.
-In that case files from `add_files` will be added before commiting.
 
 #### Parameters
 
      * `from`: Path to the folder containing the osc checkout
-     * `remove_files`: Array of file names to remove.
      * `build.repository`: Repository to build for
      * `build.arch`: Arch to build for
      * `commit.message`: Commit message for new revision
-     * `commit.add_files`: Add these files before commiting
 
 #### Example
 
@@ -84,14 +82,9 @@ In that case files from `add_files` will be added before commiting.
     - put: osc-resource
       params:
         from: osc-resource
-        remove_files:
-        - test.tmp
-        - build-stamp
         build:
           repository: openSUSE_Leap_42.1
           arch: x86_64
         commit:
           message: new release
-          add_files:
-          - "*.tgz"
 ```

--- a/assets/out
+++ b/assets/out
@@ -4,14 +4,12 @@
 # Input JSON from STDIN
 # {
 #   "params": {
-#     "remove_files": ["test.tmp", "build-stamp"],
 #     "build": {
 #       "repository": "openSUSE_Leap_42.1",
 #       "arch": "x86_64"
 #     },
 #     "commit": {
 #       "message": "new release",
-#       "add_files": ["*.tgz"]
 #     }
 #   },
 #   "source": {
@@ -48,7 +46,6 @@ build=$(jq -r '.params.build // ""' < $payload)
 repository=$(jq -r '.params.build.repository // ""' < $payload)
 arch=$(jq -r '.params.build.arch // ""' < $payload)
 commit_message=$(jq -r '.params.commit.message // ""' < $payload)
-files_count=$(jq -r '.params.remove_files | length' < $payload)
 
 if [ -z "$resource" ]; then
   echo "invalid payload (missing resource)"
@@ -57,21 +54,13 @@ fi
 
 cd $source/$resource
 
-for i in $(seq 0 $(expr "$files_count" - 1)); do
-  file=$(jq -r ".params.remove_files[$i]" < $payload)
-  osc rm -f "$file"
-done
+osc addremove
 
 if [ ! -z "$build" ]; then
   osc build --trust-all-projects $repository $arch
 fi
 
 if [ ! -z "$commit_message" ]; then
-  files_count=$(jq -r '.params.commit.add_files | length' < $payload)
-  for i in $(seq 0 $(expr "$files_count" - 1)); do
-    file=$(jq -r ".params.commit.add_files[$i]" < $payload)
-    osc add "$file"
-  done
   osc commit -m"$commit_message"
 fi
 

--- a/examples/pipeline-build.yml
+++ b/examples/pipeline-build.yml
@@ -52,6 +52,4 @@ jobs:
         repository: openSUSE_Leap_42.1
         arch: x86_64
       commit:
-        add_files:
-        - test
         message: "new automatic release via concourse"

--- a/examples/pipeline.yml
+++ b/examples/pipeline.yml
@@ -49,6 +49,4 @@ jobs:
     params:
       from: osc-updated
       commit:
-        add_files:
-        - test
         message: "new automatic release via concourse"

--- a/test/out_test.sh
+++ b/test/out_test.sh
@@ -10,14 +10,12 @@ sh assets/out tmp <<EOF
 {
   "params": {
      "from": "home:mmanno/restic",
-     "remove_files": ["test.tmp", "build-stamp"],
      "build": {
        "repository": "openSUSE_Leap_42.1",
        "arch": "x86_64"
      },
      "commit": {
        "message": "new release",
-       "add_files": ["*.tgz"]
      }
   },
   "source": {


### PR DESCRIPTION
In my oppinion having a static list of files to be added or removed does
not make much sense for Concourse because pipelines are run multiple
times and after the commit there is no need to add or remove the same
file again because the package already reflects this change.

There are also cases where somebody during pipeline creation does not
know the file name which needed to be added to the package.

So instead of using this parameters I have added `osc addremove` to be
run all the time before building or committing the package.
This takes the content of the resource directory as a given, so removing
files is done the same way as adding files to the directory via a
Concourse task.